### PR TITLE
fix(bash): make script names consistent

### DIFF
--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -84,19 +84,19 @@ if [ -x /usr/bin/dircolors ]; then
     alias egrep='egrep --color=auto'
 fi
 
-if [ -f ~/.bash_env ]; then
-    . ~/.bash_env
+if [ -f ~/.my_env ]; then
+    . ~/.my_env
 fi
 
-if [ -f ~/.bash_tools ]; then
-    . ~/.bash_tools
+if [ -f ~/.my_tools ]; then
+    . ~/.my_tools
 fi
 
 # Alias definitions.
 # See /usr/share/doc/bash-doc/examples in the bash-doc package.
 
-if [ -f ~/.bash_aliases ]; then
-    . ~/.bash_aliases
+if [ -f ~/.my_aliases ]; then
+    . ~/.my_aliases
 fi
 
 # If not running interactively, don't do anything

--- a/dot_my_aliases
+++ b/dot_my_aliases
@@ -1,4 +1,4 @@
-#!${SHELL}
+#!/bin/bash
 echo "Starting '${0}'" # echo "${1}" # echo "3_aliases"
 
 # shell aliases for bash are also in .bash_it/aliases/available
@@ -51,4 +51,4 @@ alias docker=podman
 alias ecr-login='aws ecr get-login-password --region $AWS_REGION | podman login $ECR_URL --username AWS --password-stdin'
 
 # kubernetes
-source ./tools/kube-aliases
+source .tools/kube-aliases

--- a/dot_my_tools.tmpl
+++ b/dot_my_tools.tmpl
@@ -2,7 +2,7 @@
 #!/bin/zsh
 {{ else if eq .chezmoi.os "linux" }}
 # linux
-#!/usr/bin/bash
+#!/bin/bash
 {{ end }}
 echo "Starting '${0}'"
 
@@ -53,7 +53,7 @@ echo ''
 echo 'Current python version:'
 asdf current python
 # Make sure python pip is up to date
-# echo 'Upgrade PIP'
+echo 'Upgrade PIP'
 command -v python3 && python3 -m pip install --user --upgrade pip
 
 echo ''
@@ -98,10 +98,10 @@ function getconfig() {
 }
 
 # Enable kubectl autocomplete
-# complete -o default -C $(kubectl completion bash) -F __start_kubectl kubectl
-# complete -o default -F __start_kubectl k
+command -v kubectl && complete -o default -C $(kubectl completion bash) -F __start_kubectl kubectl
+command -v kubectl && complete -o default -F __start_kubectl k
 
-test "$TERM_PROGRAM" = "WarpTerminal" || source <(kubectl completion bash)
+test "$TERM_PROGRAM" = "WarpTerminal" || command -v kubectl && source <(kubectl completion bash)
 
 # Enable terraform autocomplete
-complete -C "$(asdf which terraform)" terraform
+command -v terraform && complete -C "$(asdf which terraform)" terraform

--- a/dot_tools/kube-aliases
+++ b/dot_tools/kube-aliases
@@ -1,4 +1,4 @@
-#!${SHELL}
+#!/bin/bash
 echo "Starting ${0}"
 
 alias k='kubectl'

--- a/run_asdf_setup.tmpl
+++ b/run_asdf_setup.tmpl
@@ -5,9 +5,9 @@ https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/asdf
 git clone https://github.com/asdf-vm/asdf.git ~/.asdf
 
 {{ else if eq .chezmoi.os "linux" }}
-# linux
 #!/bin/bash
 
+# Install ASDF from github
 LATEST_VERSION=$(curl -sL https://api.github.com/repos/asdf-vm/asdf/releases/latest | jq -r ".tag_name" | cut -c2-)
 git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch "v${$LATEST_VERSION}"
 

--- a/run_brew_setup.tmpl
+++ b/run_brew_setup.tmpl
@@ -2,10 +2,8 @@
 {{ if eq .chezmoi.os "darwin" }}
 # Install Homebrew
 # https://brew.sh/
-echo "Detected MacOS; Installing Homebrew"
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 {{ else if eq .chezmoi.os "linux" }}
-# linux
 echo "Detected Linux; Installing snapd"
 # This may need to be reconsidered, if it turns out to be unsafe
 # to install snapd on a system that already has it


### PR DESCRIPTION
This pull request includes several updates and improvements to various shell configuration and setup files. The most important changes include renaming files, modifying environment and alias sourcing, and ensuring compatibility with different shells.

### File renaming and shebang updates:
* Renamed `dot_bash_aliases` to `dot_my_aliases` and updated the shebang from `${SHELL}` to `#!/bin/bash` for consistency.
* Updated the shebang in `dot_my_tools.tmpl` and `dot_tools/kube-aliases` to use `#!/bin/bash` instead of `#!/usr/bin/bash` and `${SHELL}`, respectively. [[1]](diffhunk://#diff-dc77f2a002ed58a84fe8ab83f5c0eb5bdb854c891c3fed09f2401ff76ef2d97dL5-R5) [[2]](diffhunk://#diff-a85e331c6bf9433d6abbd47033b98c142972ab2bd6ee4e3034847c4a98412de6L1-R1)

### Environment and alias sourcing:
* Modified `.bashrc` to source environment and alias files with new names (`.my_env`, `.my_tools`, `.my_aliases`).
* Updated the path for sourcing `kube-aliases` in `dot_my_aliases` to `.tools/kube-aliases`.

### Enhancements to tool setup:
* Enabled `kubectl` and `terraform` autocompletion only if the commands are available, improving robustness.
* Ensured `pip` upgrade command is executed by uncommenting the relevant line in `dot_my_tools.tmpl`.

These changes improve the maintainability and functionality of the shell configuration files by ensuring consistent naming conventions, enhancing compatibility, and making the setup scripts more robust.