### PR TITLE
style: specify script names 

### DIFF
--- a/dot_my_aliases
+++ b/dot_my_aliases
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo "Starting '${0}'" # echo "${1}" # echo "3_aliases"
+echo "Starting .my_aliases"
 
 # shell aliases for bash are also in .bash_it/aliases/available
 

--- a/dot_my_env.tmpl
+++ b/dot_my_env.tmpl
@@ -4,7 +4,7 @@
 # linux
 #!/bin/bash
 {{- end }}
-echo "Starting '${0}'"
+echo "Starting .my_env"
 
 # ensure go path is defined, and also add GOPATH/bin in PATH
 export GOPATH="${HOME}/go"

--- a/dot_my_tools.tmpl
+++ b/dot_my_tools.tmpl
@@ -4,7 +4,7 @@
 # linux
 #!/bin/bash
 {{- end }}
-echo "Starting '${0}'"
+echo "Starting .my_tools"
 
 {{- if eq .chezmoi.os "linux" }}
 if [[ "$TERM_PROGRAM" != "WarpTerminal" ]]; then

--- a/dot_tools/kube-aliases
+++ b/dot_tools/kube-aliases
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo "Starting ${0}"
+echo "Loading kube_aliases"
 
 alias k='kubectl'
 alias kp='k get pods -n $n'

--- a/private_dot_gitconfig.tmpl
+++ b/private_dot_gitconfig.tmpl
@@ -81,8 +81,8 @@
 [diff]
   # Also: EDITOR is probably set in env
 {{- if eq .chezmoi.os "darwin" }}
-	guitool = code -r
-	tool =  code -rmeld
+	guitool = code -d
+	tool =  code -d
 {{- else if eq .chezmoi.os "linux" }}
 	guitool = meld
 	tool = meld

--- a/run_asdf_setup.tmpl
+++ b/run_asdf_setup.tmpl
@@ -1,14 +1,24 @@
-{{- if eq .chezmoi.os "darwin" }}
-#!/bin/zsh
-
-# Install ASDF for Oh-My-ZSH
-https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/asdf
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf
-{{- else if eq .chezmoi.os "linux" }}
 #!/bin/bash
+echo 'Starting asdf_setup'
+echo ''
+{{- if eq .chezmoi.os "darwin" }}
 
-# Install ASDF from github
-LATEST_VERSION=$(curl -sL https://api.github.com/repos/asdf-vm/asdf/releases/latest | jq -r ".tag_name" | cut -c2-)
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch "v${LATEST_VERSION}"
+# Check if ASDF is setup
+if [[ -d "${HOME}/.asdf" ]]; then
+    echo '  ~/.asdf already exists. Skipping add plugin for Oh-My-ZSH'
+else
+    # Install ASDF for Oh-My-ZSH
+    https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/asdf
+    git clone https://github.com/asdf-vm/asdf.git ~/.asdf
+fi
+{{- else if eq .chezmoi.os "linux" }}
 
+# Check if ASDF is setup
+if [[ -d "${HOME}/.asdf" ]]; then
+    echo '  ~/.asdf already exists.'
+else
+    # Install ASDF from github
+    LATEST_VERSION=$(curl -sL https://api.github.com/repos/asdf-vm/asdf/releases/latest | jq -r ".tag_name" | cut -c2-)
+    git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch "v${LATEST_VERSION}"
+fi
 {{- end }}

--- a/run_git_setup
+++ b/run_git_setup
@@ -1,6 +1,6 @@
 #!${SHELL}
 # Configure git global settings
-echo "Starting ${0}"
+echo "Starting git_setup"
 echo ""
 echo "Displaying git global settings:"
 echo "---"

--- a/run_tools_setup.tmpl
+++ b/run_tools_setup.tmpl
@@ -1,8 +1,7 @@
-#!${SHELL}
+#!/bin/bash
 # Configure git global settings
 echo "Starting tools_setup"
 echo ""
-#!/bin/bash
 {{ if eq .chezmoi.os "darwin" }}
 echo "Detected MacOS ..."
 # Warp Terminal

--- a/run_tools_setup.tmpl
+++ b/run_tools_setup.tmpl
@@ -1,6 +1,6 @@
 #!${SHELL}
 # Configure git global settings
-echo "Starting ${0}"
+echo "Starting tools_setup"
 echo ""
 #!/bin/bash
 {{ if eq .chezmoi.os "darwin" }}


### PR DESCRIPTION
This pull request includes several changes to improve the readability and consistency of startup messages in various script files. The most important changes include updating the startup echo messages to be more descriptive and modifying the git configuration for better tool integration.

Improvements to startup messages:

* [`dot_my_aliases`](diffhunk://#diff-f7e8f92b7b541308c745d2d2eef741a9fc28654bb7654c36925f55146a818aa0L2-R2): Changed the startup message from "Starting '${0}'" to "Starting .my_aliases".
* [`dot_my_env.tmpl`](diffhunk://#diff-e77c1bc44a1002a7197561cb77f4c3370ca944fe4fb8e2ad2531fed125621652L7-R7): Changed the startup message from "Starting '${0}'" to "Starting .my_env".
* [`dot_my_tools.tmpl`](diffhunk://#diff-dc77f2a002ed58a84fe8ab83f5c0eb5bdb854c891c3fed09f2401ff76ef2d97dL7-R7): Changed the startup message from "Starting '${0}'" to "Starting .my_tools".
* [`dot_tools/kube-aliases`](diffhunk://#diff-a85e331c6bf9433d6abbd47033b98c142972ab2bd6ee4e3034847c4a98412de6L2-R2): Changed the startup message from "Starting ${0}" to "Loading kube_aliases".
* [`run_git_setup`](diffhunk://#diff-df6e269fd196d5539a39cf86422df3b2eda0c16ef39de074eb4d822122ad4f98L3-R3): Changed the startup message from "Starting ${0}" to "Starting git_setup".
* [`run_tools_setup.tmpl`](diffhunk://#diff-99291ef57af6feeebee7b51ac9bfd0cd8aaf20b6c3921b1161f3d52fb6436e0cL3-R3): Changed the startup message from "Starting ${0}" to "Starting tools_setup".

Git configuration improvements:

* [`private_dot_gitconfig.tmpl`](diffhunk://#diff-37ff7c1c71b34be2490ba47a880edcc623aed3cf5d86c2aaee098269ad12f6daL84-R85): Updated the git diff tool configuration for macOS to use "code -d" instead of "code -r" and "code -rmeld".