### PR TITLE
fix(ci): use built-in GITHUB_TOKEN for release auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Release
         uses: huggingface/semver-release-action@v1.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN_BCDADY_PUSH }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the Release workflow failing on push to `main` with `ENOGHTOKEN No GitHub token specified`. The job set `GITHUB_TOKEN` from `secrets.TOKEN_BCDADY_PUSH`, which resolved to empty at runtime (an environment-scoped secret used by a job that declares no `environment:`).

Switches to the built-in `GITHUB_TOKEN` — the job already grants `contents: write`, and the action only creates a tag + GitHub Release (no commit push-back), so the auto-provided token is sufficient. Also adds `fetch-depth: 0` so semantic-release sees full history/tags and computes the next version correctly.

Test plan:
- [ ] On merge to `main`, the Release action authenticates and completes without error
- [ ] A new SemVer release is created (this `fix:` commit yields a patch bump from v1.0.2)

Closes #20

[Warp conversation](https://app.warp.dev/conversation/f161aefc-d75f-4684-9f27-ccb8c18cf782)

Co-Authored-By: Oz <oz-agent@warp.dev>