### PR TITLE
ci: modernize semgrep workflow, prune dependabot gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,11 +12,11 @@ name: Semgrep
 jobs:
   semgrep:
     name: Scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:
-      image: returntocorp/semgrep
+      image: semgrep/semgrep
     steps:
       - uses: actions/checkout@v6
       - run: semgrep ci


### PR DESCRIPTION
Modernizes the Semgrep `Scan` job and trims dead Dependabot config:

- `runs-on: ubuntu-20.04` → `ubuntu-latest`. The Ubuntu 20.04 hosted-runner image was fully retired on 2025-04-15, so the job could no longer be scheduled.
- Semgrep container `returntocorp/semgrep` → `semgrep/semgrep` (legacy image name after Semgrep's rebrand).
- Drops the `gomod` Dependabot ecosystem — there is no `go.mod` or Go code in this repo, so it only produced updater errors.

Note: Dependabot's `github-actions` updater does not manage `runs-on:` labels or `container:` images, so these had to be changed by hand.

Test plan:
- [ ] Semgrep workflow runs on `ubuntu-latest` without runner/image errors
- [ ] Dependabot no longer logs a missing go.mod error

[Warp conversation](https://app.warp.dev/conversation/f161aefc-d75f-4684-9f27-ccb8c18cf782)

Co-Authored-By: Oz <oz-agent@warp.dev>