### PR TITLE
docs: add AGENTS.md requiring signed-off, conventional commits

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,3 +1,4 @@
+AGENTS.md
 .zshrc
 {{- if ne .chezmoi.os "darwin" }}
 .macos

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+Project rules for agents working in this repository. These dotfiles are managed
+by [chezmoi](https://chezmoi.io): the repo root is the chezmoi source directory,
+so most files are applied into `$HOME`.
+
+## Commits
+- **Sign off every commit.** Run `git commit -s` so each commit carries a
+  `Signed-off-by` trailer (Developer Certificate of Origin). Commits without a
+  sign-off are not accepted.
+- **Use Conventional Commits** for the subject line: `type(scope): summary`
+  (e.g. `fix:`, `feat:`, `ci:`, `docs:`, `chore:`). Pull requests to `main` are
+  validated by a Conventional Commit Checker, and release versions are derived
+  from commit types (`feat:` → minor, `fix:` → patch).


### PR DESCRIPTION
Adds project rules (`AGENTS.md`) so agents working in this repo sign off and follow Conventional Commits — codifying the repo's existing DCO and commit-checker requirements.

- Every commit must be signed off: `git commit -s` (`Signed-off-by` / DCO).
- Conventional Commits required (validated by the Conventional Commit Checker on PRs to `main`).

`AGENTS.md` is also added to `.chezmoiignore` so chezmoi does not apply it into `$HOME` (verified with `chezmoi ignored`).