### PR TITLE
chore(mise): normalize tool versions and tidy aliases

### DIFF
--- a/dot_mise.toml
+++ b/dot_mise.toml
@@ -1,7 +1,7 @@
 [env]
 AWS_CLI_AUTO_PROMPT = 'on-partial'
 AWS_DEFAULT_REGION = 'us-west-2'
-AWS_PROFILE = 'infra'
+AWS_PROFILE = 'dev'
 AWS_RETRY_MODE = 'adaptive'
 
 EDITOR = "code -r"
@@ -10,30 +10,30 @@ RUST_WITHOUT = 'rust-docs'
 
 [tools]
 # AWS and Cloud Tools
-awscli = "latest"
-terraform = "prefix:1.12"
+awscli = "prefix:2"
+terraform = "prefix:1"
 terraform-docs = "prefix:0"
-tflint = "latest"
-vault = "prefix:1"
+tflint = "prefix:0"
+vault = "prefix:2"
 
 # Kubernetes Tools
-helm = "prefix:3.16"
-krew = "latest"
-kube-linter = "latest"
-kubectl = "prefix:1.32"
-kubectx = "prefix:0.9"
-kubie = "latest"
+helm = "prefix:3"
+krew = "prefix:0"
+kube-linter = "prefix:0"
+kubectl = "prefix:1"
+kubectx = "prefix:0"
+kubie = "prefix:0"
 
 # Development Languages
-golang = "prefix:1.24"
-nodejs = "23.5.0"
-python = "prefix:3.12"
+golang = "prefix:1"
+nodejs = "lts"
+python = "prefix:3"
 
 # Development Tools
-bazel = "5.2.0"
+bazel = "prefix:5"
 bitwarden = "latest"
-checkov = "3.2.2"
-dasel = "2.8.1"
+checkov = "prefix:3"
+dasel = "prefix:2"
 gitconfig = "latest"
 glab = "latest"
 hadolint = "latest"
@@ -41,9 +41,8 @@ jq = "latest"
 mysql = "prefix:8.0"
 tfsec = "latest"
 yamllint = "latest"
-yarn = "latest"
+yarn = "prefix:3"
 
 # Python Tools
 ruff = "latest"
 uv = "latest"
-

--- a/dot_my_aliases
+++ b/dot_my_aliases
@@ -57,10 +57,6 @@ alias mrwip='glab mr --message "WIP" --remove_source_branch --squash --target $(
 # alias dockerstatus='systemctl --user status docker --no-pager'
 # alias dockerstop='systemctl --user stop docker --no-pager'
 
-# ECR login
-alias docker=podman
-alias ecr-login='aws ecr get-login-password --region $AWS_REGION | docker login $ECR_URL --username AWS --password-stdin'
-
 # kubernetes-specific aliases
 test -f "${HOME}/.tools/kube-aliases" && . "${HOME}/.tools/kube-aliases" || echo "Error: ${HOME}/.tools/kube-aliases Not found"
 

--- a/dot_my_env.tmpl
+++ b/dot_my_env.tmpl
@@ -7,30 +7,5 @@
 # ensure go path is defined, and also add GOPATH/bin in PATH
 # export GOPATH="${HOME}/go"
 
-# GOBIN="${GOPATH}/bin"
-
-# Add GOBIN to PATH
-# export PATH="$GOBIN:$PATH"
-
-# Mise paths handled by mise activate
-# AUTH_TOKEN (JWT)
-# export AUTH_TOKEN="DO NOT COMMIT SECRETS"
-
-# GITLAB ACCESS_KEY
-# export GITLAB_TOKEN="DO NOT COMMIT SECRETS"
-# export GITLAB_HOST="DO NOT COMMIT SECRETS"
-# export EDITOR="code -r"
-
-# AWS CLI
-# https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-# export AWS_DEFAULT_REGION='us-west-2'
-# See also "aws cli autocomplete" in ./2_tools
-# export AWS_CLI_AUTO_PROMPT='on-partial'
-# export AWS_PROFILE='prod'
-# export AWS_RETRY_MODE='adaptive'
-
 # Add Krew to PATH
 export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
-
-# Rust config (for mise)
-# export RUST_WITHOUT=rust-docs

--- a/dot_my_tools.tmpl
+++ b/dot_my_tools.tmpl
@@ -73,17 +73,6 @@ if [[ "$TERM_PROGRAM" != "kiro" ]] && [[ "$TERM_PROGRAM" != "WarpTerminal" ]]; t
 fi
 {{- end }}
 
-# list available versions of python
-# echo 'Available python (3) versions / updates:'
-# mise ls-remote python | grep -E '^3\.[0-9]{1,3}\.[0-9]{1,3}$' | tail -n 10
-# # check which python is active via mise
-# echo ''
-# echo 'Current python version:'
-# mise current python
-# # Make sure python pip is up to date
-# echo 'Upgrade PIP'
-# command -v python3 && python3 -m pip install --user --upgrade pip
-
 # echo ''
 {{- if eq .chezmoi.os "linux" }}
 # configure vpn aliases for CLI on linux

--- a/run_tools_setup.tmpl
+++ b/run_tools_setup.tmpl
@@ -12,7 +12,7 @@ command_exists() {
 install_tool() {
     local tool="$1"
     local install_cmd="$2"
-    
+
     if ! command_exists "$tool"; then
         echo "Installing $tool..."
         eval "$install_cmd" || {
@@ -67,7 +67,7 @@ install_deb() {
     local name="$1"
     local url="$2"
     local filename="$3"
-    
+
     echo "Downloading $name..."
     wget "$url" -O "$TOOLS_DIR/$filename" || return 1
     sudo dpkg -i "$TOOLS_DIR/$filename" || {
@@ -77,6 +77,7 @@ install_deb() {
     rm -f "$TOOLS_DIR/$filename"  # Cleanup
 }
 
+# TODO refactor to replace snap; not reliable for slack, etc.
 # Core development tools
 install_tool git "sudo apt install -y git-all"
 install_tool code "sudo snap install code --classic"


### PR DESCRIPTION
- Use prefix: version constraints instead of pinned versions
- Switch nodejs to lts
- Remove stale commented-out env vars and dead code