### PR TITLE
fix(ci):  Workflows do not set permissions

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
     types: [opened, edited, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   check-for-cc:
     runs-on: ubuntu-latest

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,6 +9,8 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 name: Semgrep
+permissions:
+  contents: read
 jobs:
   semgrep:
     name: Scan


### PR DESCRIPTION
Potential fix for [https://github.com/bcdady/dotfiles/security/code-scanning/11](https://github.com/bcdady/dotfiles/security/code-scanning/11)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here (without changing behavior) is to set workflow-level permissions to:

- `contents: read`

This is sufficient for `actions/checkout` and a scan-only workflow, and it applies to all jobs unless overridden.  
Change location: `.github/workflows/semgrep.yml`, near the top-level keys (right after `name` is clean and conventional).  
No new imports/methods/dependencies are needed—just YAML key insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
