### PR TITLE
fix(shell): auto-invalidate glab token cache when config.yml is newer

### DIFF
--- a/dot_config/shell/gitlab-token.sh
+++ b/dot_config/shell/gitlab-token.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 # gitlab-token.sh — POSIX-compatible, safe to source from .profile and .bashrc
-# Caches GITLAB_TOKEN (24h) and GITLAB_HOST (persistent, prompted on first use).
+# Caches GITLAB_TOKEN (1h) and GITLAB_HOST (persistent, prompted on first use).
+# Cache is auto-invalidated when ~/.config/glab-cli/config.yml is newer.
+#
+# Token rotation workflow:
+#   1. Rotate token in GitLab UI
+#   2. glab auth login --hostname subsplash.io   # updates config.yml
+#   3. gitlab-token-refresh                       # or open a new shell
+#
+# Force-refresh in the current shell:
+#   . ~/.config/shell/gitlab-token.sh refresh
 
 _gldir="$HOME/.cache"
+_gl_force_refresh=0
+case "${1:-}" in refresh|force|-f) _gl_force_refresh=1 ;; esac
 
 # --- GITLAB_HOST (persistent cache, interactive prompt on first use) ---
 if [ -z "${GITLAB_HOST:-}" ]; then
@@ -29,22 +40,35 @@ if [ -z "${GITLAB_HOST:-}" ]; then
   unset _glhost_cache
 fi
 
-# --- GITLAB_TOKEN (24h cache) ---
-if [ -z "${GITLAB_TOKEN:-}" ]; then
+# --- GITLAB_TOKEN (1h cache, auto-invalidated when config.yml is newer) ---
+# Skip if already set AND not forcing a refresh.
+if [ -z "${GITLAB_TOKEN:-}" ] || [ "$_gl_force_refresh" -eq 1 ]; then
   _gltoken_cache="$_gldir/glab_token"
-  if [ -f "$_gltoken_cache" ] && [ "$(( $(command date +%s) - $(stat -c %Y "$_gltoken_cache") ))" -lt 86400 ]; then
+  _glconfig="$HOME/.config/glab-cli/config.yml"
+  # Use cache if: not forcing refresh, exists, <1h old, and not older than config.yml
+  if [ "$_gl_force_refresh" -eq 0 ] \
+      && [ -f "$_gltoken_cache" ] \
+      && [ "$(( $(command date +%s) - $(stat -c %Y "$_gltoken_cache") ))" -lt 3600 ] \
+      && { [ ! -f "$_glconfig" ] || [ "$_gltoken_cache" -nt "$_glconfig" ]; }; then
     GITLAB_TOKEN=$(cat "$_gltoken_cache")
   elif command -v glab >/dev/null 2>&1; then
-    GITLAB_TOKEN=$(timeout 3 glab auth status --show-token 2>&1 | grep "Token found" | awk '{print $NF}')
+    # Unset so glab reads from config.yml, not the (possibly stale) env var.
+    # Prefer `glab config get` (reads config.yml directly, no API call, no fragile parse).
+    _gl_prev_token="${GITLAB_TOKEN:-}"
+    unset GITLAB_TOKEN
+    GITLAB_TOKEN=$(glab config get --host subsplash.io token 2>/dev/null)
     if [ -n "$GITLAB_TOKEN" ]; then
       mkdir -p "$_gldir"
       printf '%s' "$GITLAB_TOKEN" > "$_gltoken_cache"
     else
-      echo "Warning: could not retrieve GITLAB_TOKEN — ${GITLAB_HOST:-GitLab host} may be unreachable (VPN connected?)" >&2
+      # Fall back to previous value if the refresh failed
+      GITLAB_TOKEN="$_gl_prev_token"
+      echo "Warning: could not read GITLAB_TOKEN from glab config (~/.config/glab-cli/config.yml). Run: glab auth login --hostname subsplash.io" >&2
     fi
+    unset _gl_prev_token
   fi
   [ -n "${GITLAB_TOKEN:-}" ] && export GITLAB_TOKEN
-  unset _gltoken_cache
+  unset _gltoken_cache _glconfig
 fi
 
-unset _gldir
+unset _gldir _gl_force_refresh

--- a/dot_my_aliases.tmpl
+++ b/dot_my_aliases.tmpl
@@ -67,3 +67,5 @@ awsactive() {
 
 # GitLab CLI auth
 alias glab-login='glab auth login --hostname subsplash.io --api-protocol https --web'
+# Force-refresh GITLAB_TOKEN in the current shell (clears 1h cache, re-reads from glab config.yml)
+alias gitlab-token-refresh='. ~/.config/shell/gitlab-token.sh refresh'


### PR DESCRIPTION
## Problem

`gitlab-token.sh` cached `GITLAB_TOKEN` for **24 hours**, but the TTL check ignored the mtime of `~/.config/glab-cli/config.yml`. After running `glab auth login` (or otherwise updating the config), the shell kept re-exporting the stale cached token for up to a day.

Because `glab` prefers `$GITLAB_TOKEN` over `config.yml`, this masked the rotation and produced 401 errors from `api.subsplash.io` such as:

```
GET https://subsplash.io/api/v4/user: 401 {error: invalid_token},
{error_description: Token is expired. You can either do re-authorization or token refresh.}
! Token is from environment variable GITLAB_TOKEN. A wrapper may be injecting a different or expired token.
```

## Changes

- **Cache TTL 24h → 1h.** Automatic recovery from any rotation within an hour without user action.
- **Auto-invalidate cache when `config.yml` is newer.** Uses POSIX `-nt` test; picks up rotations immediately in any new shell.
- **Read token via `glab config get --host` instead of parsing `glab auth status --show-token`.** No API call, no VPN dependency, no fragile `grep`/`awk`. Faster shell startup.
- **Warning message updated** to point at the actual remediation (`glab auth login`) instead of a red-herring VPN hint.
- **Add previously-untracked `gitlab-token-refresh` alias** to `dot_my_aliases.tmpl` (its comment now correctly says "1h cache").
- **Docstring updated** with the correct token-rotation workflow.

## Testing

Sourced the new script in fresh subshells and verified:

| Scenario | Result |
|---|---|
| Cold start (no cache, no env) | Token populated from `config.yml`, cache created |
| Cache hit (fresh cache, no env) | Cached value served |
| `refresh` argument | Cache mtime advances, value re-read from config |
| `config.yml` touched newer than cache | Cache auto-refreshed on next source |
| `GITLAB_TOKEN` preset in env | Preserved, no-op (unchanged behavior) |

Syntax validated with `sh -n`, `dash -n`, `bash -n`.